### PR TITLE
fix: collapse duplicate Graphik __init__ into a single constructor

### DIFF
--- a/src/main/python/preponderous/graphik/graphik.py
+++ b/src/main/python/preponderous/graphik/graphik.py
@@ -6,18 +6,21 @@ from ._version import __version__
 #  @author Daniel McCoy Stephenson
 #  @since February 3rd, 2022
 class Graphik:
-    def __init__(self):
-        displayWidth = 900
-        displayHeight = 600
-        self.gameDisplay = pygame.display.set_mode((displayWidth, displayHeight))
+    # Color constants, reachable as Graphik.white or instance.white, etc.
+    black = (0, 0, 0)
+    white = (255, 255, 255)
+    red = (200, 0, 0)
+    green = (0, 200, 0)
+    blue = (0, 0, 200)
 
-        self.black = (0,0,0)
-        self.white = (255,255,255)
-        self.red = (200,0,0)
-        self.green = (0,200,0)
-        self.blue = (0,0,200)
-
-    def __init__(self, gameDisplay):
+    def __init__(self, gameDisplay=None):
+        # Consumers normally pass their own gameDisplay-backed surface. When
+        # none is supplied, fall back to a default 900x600 window so the
+        # no-argument Graphik() form works instead of raising.
+        if gameDisplay is None:
+            displayWidth = 900
+            displayHeight = 600
+            gameDisplay = pygame.display.set_mode((displayWidth, displayHeight))
         self.gameDisplay = gameDisplay
 
     def getGameDisplay(self):

--- a/src/test/python/preponderous/graphik/test_graphik.py
+++ b/src/test/python/preponderous/graphik/test_graphik.py
@@ -29,6 +29,32 @@ def test_get_version_matches_package_version():
     assert graphik.getVersion() == graphik_pkg.__version__
 
 
+def test_constructor_stores_supplied_display():
+    # The explicit-display form every consumer uses keeps working.
+    pygame.display.init()
+    display = pygame.display.set_mode((10, 10))
+    graphik = Graphik(display)
+    assert graphik.getGameDisplay() is display
+
+
+def test_no_arg_constructor_creates_default_display():
+    # Graphik() must be reachable (it was dead code behind a duplicate __init__)
+    # and fall back to a default display rather than raising TypeError.
+    graphik = Graphik()
+    assert graphik.getGameDisplay() is not None
+
+
+def test_color_constants_are_reachable():
+    # The color constants used to be assigned only in an unreachable __init__;
+    # they must now be present on both the class and any instance.
+    assert Graphik.white == (255, 255, 255)
+    assert Graphik.black == (0, 0, 0)
+    assert Graphik.red == (200, 0, 0)
+    assert Graphik.green == (0, 200, 0)
+    assert Graphik.blue == (0, 0, 200)
+    assert _make_graphik().white == (255, 255, 255)
+
+
 def test_package_imports_without_pygame():
     # Regression guard for the lazy Graphik import: importing the package (as
     # setuptools does to resolve the dynamic version) must not require pygame.


### PR DESCRIPTION
## Summary
- `Graphik` defined `__init__` twice; the second (`__init__(self, gameDisplay)`) silently shadowed the first, so the no-arg constructor and the `black`/`white`/`red`/`green`/`blue` defaults were unreachable dead code (`Graphik()` raised `TypeError`; `instance.white` raised `AttributeError`).
- Consolidated to a single `__init__(self, gameDisplay=None)` that falls back to a default 900×600 display when no surface is supplied, so the no-arg form now works.
- Promoted the color constants to class-level, so both `Graphik.white` and `instance.white` resolve.

## Decision (the fork flagged in #7)
Option B (single ctor with `gameDisplay=None` default) was chosen over Option A (drop the no-arg form), combined with class-level color constants. This makes every member that *looked* like public surface actually work, while keeping the change **purely additive**: the explicit `Graphik(gameDisplay)` form every known consumer (Roam, Apex, Ophidian, Patchwork, Tic-Tak-Toe) uses is unchanged, so no consumer breaks and no version bump is required.

## Acceptance criteria (#7)
- [x] `Graphik` has exactly one `__init__`.
- [x] The constructor contract is covered by headless tests (run under `SDL_VIDEODRIVER=dummy`).
- [x] No attribute is referenced by a method the constructor never assigns — color constants are now live class attributes.

## Test plan
- [x] `python3 -m py_compile .../graphik.py` — clean
- [x] Headless import smoke — OK
- [x] `SDL_VIDEODRIVER=dummy python3 -m pytest` — 6 passed (3 new: supplied-display, no-arg default, color-constant reachability)

Closes #7

_Drafted by Claude on behalf of Daniel Stephenson._