### PR TITLE
ci: add PyPI publish-on-tag workflow (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+# Builds the sdist/wheel and publishes graphik to PyPI when a version tag is
+# pushed. Publishing uses PyPI Trusted Publishing (OIDC) -- no API token is
+# stored in the repo. See RELEASING.md for the one-time PyPI configuration and
+# the release procedure.
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+# Least privilege by default; the publish job opts into id-token below.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Verify the tag matches the package version
+        run: |
+          PKG_VERSION="$(python -c 'import sys; sys.path.insert(0, "src/main/python"); from preponderous.graphik._version import __version__; print(__version__)')"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "tag=$TAG_VERSION package=$PKG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} ($TAG_VERSION) does not match package version $PKG_VERSION. Bump src/main/python/preponderous/graphik/_version.py before tagging."
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Smoke-test the built wheel
+        run: |
+          python -m pip install dist/*.whl
+          python -c "import preponderous.graphik as g; assert g.__version__ == '${GITHUB_REF_NAME#v}', g.__version__; print('import + version OK:', g.__version__)"
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Gates the release behind the "pypi" environment so Trusted Publishing can
+    # be scoped to it on PyPI and an optional approval can be added later.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/graphik
+    permissions:
+      id-token: write # required for OIDC Trusted Publishing
+    steps:
+      - name: Download distribution artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing graphik
+
+graphik is published to [PyPI](https://pypi.org/) via **Trusted Publishing**
+(OIDC) — no API token is stored in this repository. Publishing is automated by
+[`.github/workflows/publish.yml`](.github/workflows/publish.yml), which runs
+when a version tag (`vX.Y.Z`) is pushed.
+
+## One-time setup (maintainer)
+
+These steps are prerequisites for the workflow to succeed and are done outside
+this repository:
+
+1. **Claim the project name on PyPI.** Register `graphik` (the
+   [`pyproject.toml`](pyproject.toml) `name`). `preponderous-graphik` is the
+   namespaced fallback if the name is unavailable.
+2. **Configure a Trusted Publisher** on the PyPI project pointing at this repo:
+   - Owner: `Stephenson-Software`
+   - Repository: `graphik`
+   - Workflow filename: `publish.yml`
+   - Environment name: `pypi`
+3. **Create a GitHub environment** named `pypi` (Settings → Environments). An
+   optional required-reviewer rule can be added there to gate each release.
+
+## Cutting a release
+
+1. Bump the single version source —
+   [`src/main/python/preponderous/graphik/_version.py`](src/main/python/preponderous/graphik/_version.py)
+   (`__version__`). Every other version reference is derived from it.
+2. Commit the bump and merge it to `main`.
+3. Tag the release commit and push the tag:
+
+   ````bash
+   git tag v0.2.0
+   git push origin v0.2.0
+   ````
+
+4. The `Publish to PyPI` workflow then:
+   - verifies the tag matches `__version__` (a mismatch fails the build),
+   - builds the sdist and wheel,
+   - smoke-tests the built wheel (install + canonical import + version check),
+   - publishes to PyPI via Trusted Publishing.
+
+The tag must equal `v` + `__version__` (e.g. `__version__ = "0.2.0"` → tag
+`v0.2.0`), or the build fails fast before anything is published.
+
+## Installing (after the first publish)
+
+Once the package is live on PyPI, consumers can replace their vendored copies
+with a versioned dependency:
+
+````bash
+pip install graphik
+````
+
+```python
+from preponderous.graphik import Graphik
+```
+
+Migrating the existing consumers (Roam, Apex, Ophidian, Patchwork, Tic-Tak-Toe)
+off their vendored copies is tracked as follow-up work in the consumer repos.


### PR DESCRIPTION
## Summary
Delivers the remaining in-repo packaging work for #5 — a real release pipeline. The repo previously had **no CI**.

- **`.github/workflows/publish.yml`** — triggered on a `vX.Y.Z` tag push:
  1. **Verify** the tag equals `preponderous.graphik._version.__version__` (mismatch fails fast before anything is published).
  2. **Build** the sdist + wheel (`python -m build`).
  3. **Smoke-test** the built wheel (install + `from preponderous.graphik` import + version check).
  4. **Publish** to PyPI via **Trusted Publishing (OIDC)** — no API token stored in the repo. The publish job is scoped to a `pypi` GitHub environment with least-privilege `id-token: write`.
- **`RELEASING.md`** — documents the one-time PyPI Trusted-Publisher + GitHub-environment setup and the bump→tag→push release procedure.

## Decision context
Per the recorded decision on #5: **public PyPI (Option A)** with Trusted Publishing, canonical import `from preponderous.graphik import Graphik`. The pyproject/version-source/import-path work (steps 2–4) already shipped in #8; this PR is step 5.

## Scope / what this does NOT do
Intentionally **does not `Closes #5`** — two parts of #5 are outside a single-repo PR:
- **Step 1** — claiming the `graphik` name on PyPI (a manual account action; prerequisite documented in RELEASING.md).
- **Step 6** — migrating consumers (Roam, Apex, Ophidian, Patchwork, Tic-Tak-Toe) off vendored copies (cross-repo follow-ups).

README install instructions were deliberately left out until the package is actually published (the name isn't claimed yet, so `pip install graphik` would be a false claim today).

## Test plan
- [x] `publish.yml` parses as valid YAML; jobs `build`→`publish`, trigger `tags: v*.*.*`.
- [x] Dynamic version source resolves locally (`__version__` → `0.2.0`), so the tag-match + build version derivation are sound.
- [x] `SDL_VIDEODRIVER=dummy python3 -m pytest` — 6 passed (no source change).
- [ ] **Sandbox-unverified:** the actual `python -m build` + publish path is exercised only in CI — the `build` module is not installable in this sandbox (see graphik-dev-loop#2). Validated structurally + via the local version-source check rather than a full in-sandbox build.

## Reviewer note
This adds a release-automation workflow and is on the do-not-auto-merge list (`.github/workflows/*`), so it is intentionally left for human review. Before the first real release, the PyPI Trusted Publisher and the `pypi` GitHub environment must be configured per RELEASING.md.

Advances #5.

_Drafted by Claude on behalf of Daniel Stephenson._