### PR TITLE
feat: add Graphik.drawImage for rendering images to the screen

### DIFF
--- a/src/main/python/preponderous/graphik/graphik.py
+++ b/src/main/python/preponderous/graphik/graphik.py
@@ -49,3 +49,8 @@ class Graphik:
             click = pygame.mouse.get_pressed()
             if click[0] == 1:
                 function()
+
+    def drawImage(self, filePath, xpos, ypos, width, height):
+        image = pygame.image.load(filePath)
+        image = pygame.transform.scale(image, (width, height))
+        self.gameDisplay.blit(image, (xpos, ypos))

--- a/src/test/python/preponderous/graphik/test_graphik.py
+++ b/src/test/python/preponderous/graphik/test_graphik.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import pygame
+import pytest
 
 import preponderous.graphik as graphik_pkg
 from preponderous.graphik import Graphik
@@ -73,3 +74,34 @@ def test_package_imports_without_pygame():
     )
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == graphik_pkg.__version__
+
+
+def _write_solid_image(path, color, size=(4, 4)):
+    # BMP is supported by pygame without SDL_image, so the fixture is portable.
+    surface = pygame.Surface(size)
+    surface.fill(color)
+    pygame.image.save(surface, str(path))
+
+
+def test_draw_image_blits_scaled_image_to_position(tmp_path):
+    pygame.display.init()
+    display = pygame.display.set_mode((20, 20))
+    display.fill((0, 0, 0))
+    graphik = Graphik(display)
+
+    image_path = tmp_path / "red.bmp"
+    _write_solid_image(image_path, (255, 0, 0))
+
+    # Scale a 4x4 red image up to 10x10 and blit it at the origin.
+    graphik.drawImage(str(image_path), 0, 0, 10, 10)
+
+    # A pixel inside the drawn 10x10 region is red; one outside stays untouched.
+    assert tuple(display.get_at((5, 5)))[:3] == (255, 0, 0)
+    assert tuple(display.get_at((15, 15)))[:3] == (0, 0, 0)
+
+
+def test_draw_image_missing_file_raises(tmp_path):
+    graphik = _make_graphik()
+    missing = tmp_path / "does_not_exist.bmp"
+    with pytest.raises((FileNotFoundError, pygame.error)):
+        graphik.drawImage(str(missing), 0, 0, 10, 10)


### PR DESCRIPTION
## Summary
Implements image drawing for #2: a `Graphik.drawImage(filePath, xpos, ypos, width, height)` method that loads the image, scales it to the requested size, and blits it at the given position — matching the issue's exact contract ("file path, x position, y position, width and height").

- Follows the **minimal style of the sibling draw methods** (`drawRectangle`, `drawText`): no defensive swallowing — a bad path raises (`FileNotFoundError`/`pygame.error`) just as `drawText` lets a missing font raise. Graphik has no logging infrastructure, so this is the consistent choice.
- camelCase name, matching the existing public surface.

## Relationship to PR #4
This supersedes the stale Copilot draft **#4** (last touched 2026-02-02, based on pre-#8 `main`, no tests, with a now-redundant `.gitignore` change covered by #8). Per maintainer direction, #4 will be closed in favor of this rebased, tested implementation.

## Test plan
- [x] `python3 -m py_compile .../graphik.py` — clean
- [x] Headless import smoke — OK
- [x] `SDL_VIDEODRIVER=dummy python3 -m pytest` — **8 passed** (2 new):
  - `test_draw_image_blits_scaled_image_to_position` — a 4×4 red image scaled to 10×10 colors the in-region pixel red and leaves an out-of-region pixel untouched (verifies both blit position and scaling).
  - `test_draw_image_missing_file_raises` — a non-existent path raises `FileNotFoundError`/`pygame.error`.

Closes #2

_Drafted by Claude on behalf of Daniel Stephenson._